### PR TITLE
declaring the frame_round_corners function in frame.h

### DIFF
--- a/openbox/frame.h
+++ b/openbox/frame.h
@@ -266,6 +266,7 @@ void frame_flash_stop(ObFrame *self);
   started in the meantime, the callback will never get called. */
 void frame_begin_iconify_animation(ObFrame *self, gboolean iconifying);
 void frame_end_iconify_animation(gpointer data);
+void frame_round_corners(Window window); //prevent implicit declaration of function
 
 #define frame_iconify_animating(f) (f->iconify_animation_going != 0)
 

--- a/openbox/frame.h
+++ b/openbox/frame.h
@@ -266,7 +266,7 @@ void frame_flash_stop(ObFrame *self);
   started in the meantime, the callback will never get called. */
 void frame_begin_iconify_animation(ObFrame *self, gboolean iconifying);
 void frame_end_iconify_animation(gpointer data);
-void frame_round_corners(Window window); //prevent implicit declaration of function
+void frame_round_corners(Window window); //prevent implicit declaration of function 'frame_round_corners`
 
 #define frame_iconify_animating(f) (f->iconify_animation_going != 0)
 


### PR DESCRIPTION
Before declaring frame_round_corners, I receive this error when building it. 
```bash
openbox/framerender.c: In function ‘framerender_frame’:
openbox/framerender.c:50:9: error: implicit declaration of function ‘frame_round_corners’ [-Wimplicit-function-declaration]
   50 |         frame_round_corners(self->window);
```

So, I added this line to the frame.h to prevent the errors
`void frame_round_corners(Window window)`